### PR TITLE
config.h changed depracated _BSD_SOURCE to _DEFAULT_SOURCE

### DIFF
--- a/config.h
+++ b/config.h
@@ -14,8 +14,8 @@
 #define INTRACE_AUTHORS "(C)2007-2011 Robert Swiecki <robert@swiecki.net>"
 
 /* struct tcphdr incompabilities */
-#ifndef _BSD_SOURCE
-#define _BSD_SOURCE
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
 #endif
 
 #define MAX_HOPS 32


### PR DESCRIPTION
$ make
CC debug.c
In file included from /usr/include/stdio.h:27:0,
                 from debug.c:27:
/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
cc1: all warnings being treated as errors
Makefile:36: recipe for target 'debug.o' failed
